### PR TITLE
Allow injection of customisation scripts for use by the entrypoint

### DIFF
--- a/docker/delivery/entrypoint.sh
+++ b/docker/delivery/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
+for f in /entrypoint.d/*.sh ; do
+  if [ -f "$f" ]; then
+    . "$f"
+  fi
+done
+
 # Java returns exit code 143 when it is killed with SIGTERM, so do not treat
 # this as a failure.
 
-exec /usr/bin/tini -e 143 -- java  -Djava.security.egd=file:/dev/./urandom -jar -Dspring.profiles.active=$PROFILE weverify-wrapper-webapp.jar "$@"
+exec /usr/bin/tini -e 143 -- java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar -Dspring.profiles.active=$PROFILE weverify-wrapper-webapp.jar $APP_OPTS "$@"


### PR DESCRIPTION
There are cases where we need to be able to inject additional logic that will run at startup and pass additional options to the `java` command.  The specific use case I have in mind is if the wrapper needs to communicate with an Elasticsearch that uses https with a certificate that is not trusted by default, in which case we need to either add the relevant CA certificates to the default trust store or construct a custom truststore and set the appropriate `-Djavax.net.ssl` system properties.

This PR allows a user to bind-mount a directory of `.sh` files that will be _sourced_ (not executed) by the entrypoint before it execs `java`.  Sourcing the scripts means that they can make changes to the environment variables which will be visible to the rest of the entrypoint script.  In particular I've added `$JAVA_OPTS` and `$APP_OPTS` variables to the command line that can be filled in by injected scripts to pass parameters to `java` itself (before the `-jar` option) or to the actual app (at the end of the line, before the "CMD" parameters passed to the container).