### PR TITLE
Adding support for https Elasticsearch

### DIFF
--- a/weverify-core-library/src/main/java/com/afp/medialab/weverify/WeverifyConfiguration.java
+++ b/weverify-core-library/src/main/java/com/afp/medialab/weverify/WeverifyConfiguration.java
@@ -33,6 +33,9 @@ public class WeverifyConfiguration {
 	@Value("${application.elasticsearch.authentication}")
 	private boolean isAuthenticate;
 
+	@Value("${application.elasticsearch.secure}")
+	private boolean isSecure;
+
 	@Bean
 	public RestHighLevelClient elasticsearchClient() {
 
@@ -42,13 +45,20 @@ public class WeverifyConfiguration {
 		httpHeaders.add("Accept", "application/vnd.elasticsearch+json;compatible-with=7");
 		httpHeaders.add("Content-Type", "application/vnd.elasticsearch+json;" + "compatible-with=7");
 		String esURL = esHost + ":" + esPort;
+		final ClientConfiguration.MaybeSecureClientConfigurationBuilder baseBuilder =
+						ClientConfiguration.builder().connectedTo(esURL);
+		final ClientConfiguration.TerminalClientConfigurationBuilder terminalBuilder;
+		if(isSecure)
+			terminalBuilder = baseBuilder.usingSsl();
+		else
+			terminalBuilder = baseBuilder;
+
 		final ClientConfiguration clientConfiguration;
 		if (isAuthenticate)
-			clientConfiguration = ClientConfiguration.builder().connectedTo(esURL).withDefaultHeaders(httpHeaders)
-					.withBasicAuth(esUser, esPassword).build();
+			clientConfiguration = terminalBuilder.withBasicAuth(esUser, esPassword).build();
 		else
-			clientConfiguration = ClientConfiguration.builder().connectedTo(esURL).withDefaultHeaders(httpHeaders)
-					.build();
+			clientConfiguration = terminalBuilder.build();
+
 		return RestClients.create(clientConfiguration).rest();
 	}
 

--- a/weverify-twint-wrapper/src/main/java/com/afp/medialab/weverify/social/controller/ProxyServiceController.java
+++ b/weverify-twint-wrapper/src/main/java/com/afp/medialab/weverify/social/controller/ProxyServiceController.java
@@ -26,12 +26,24 @@ public class ProxyServiceController {
 	@Value("${application.elasticsearch.port}")
 	private String esPort;
 
+	@Value("${application.elasticsearch.secure}")
+	private boolean isSecure;
+
 	private String esURL;
 
 	@PostConstruct
 	private void init() {
+		StringBuilder urlBuilder = new StringBuilder();
+		if(!esHost.startsWith("http")) {
+			urlBuilder.append("http");
+			if(isSecure) urlBuilder.append("s");
+			urlBuilder.append("://");
+		}
+		urlBuilder.append(esHost);
+		urlBuilder.append(":");
+		urlBuilder.append(esPort);
+		this.esURL = urlBuilder.toString();
 
-		this.esURL = (esHost.startsWith("http") ? esHost : "http://" + esHost) + ":" + esPort;
 	}
 
 	@Autowired

--- a/weverify-twint-wrapper/src/main/java/com/afp/medialab/weverify/social/twint/TwintThread.java
+++ b/weverify-twint-wrapper/src/main/java/com/afp/medialab/weverify/social/twint/TwintThread.java
@@ -44,6 +44,9 @@ public class TwintThread {
 	@Value("${application.elasticsearch.authentication}")
 	private boolean isAuthenticate;
 
+	@Value("${application.elasticsearch.secure}")
+	private boolean isSecure;
+
 	@Value("${application.twint-wrapper.twintcall.twint_thread_nb_restart_on_error}")
 	private Long restart_time;
 	
@@ -98,7 +101,7 @@ public class TwintThread {
 		// String twintRequest =
 		// TwintRequestGenerator.getInstance().generateRequest(request, session,
 		// isDocker, esURL);
-		String esCnxURL = isAuthenticate ? esUser+":"+esPassword+"@"+esURL : esURL;
+		String esCnxURL = (isSecure ? "https://" : "http://" ) + (isAuthenticate ? esUser+":"+esPassword+"@" : "") + esURL;
 		String twintRequest = TwintPlusRequestBuilder.getInstance().generateRequest(request, session, isDocker, esCnxURL, limit);
 
 		ProcessBuilder processBuilder = new ProcessBuilder("/bin/bash", "-c", twintCall + twintRequest);

--- a/weverify-wrapper-webapp/src/main/resources/application.yml
+++ b/weverify-wrapper-webapp/src/main/resources/application.yml
@@ -18,6 +18,7 @@ application:
     user: ${ES_USER:elastic}
     password: ${ES_PASSWORD:twfUEvNNFWVtUv_3b8u9}
     authentication: ${ES_IS_AUTH:true}
+    secure: ${ES_IS_SECURE:false}
   notification:
     slack: ${SLACK_URL:}
        


### PR DESCRIPTION
Provide a way to configure that Elasticsearch requires https connection, and apply the right URLs in the various different components that talk to it.